### PR TITLE
Add support for log statements with 3 and 4 arguments

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/Logger.java
+++ b/slf4j-api/src/main/java/org/slf4j/Logger.java
@@ -124,6 +124,37 @@ public interface Logger {
      * Log a message at the TRACE level according to the specified format
      * and arguments.
      * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the TRACE level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     * @since 1.4
+     */
+    public void trace(String format, Object arg1, Object arg2, Object arg3);
+
+    /**
+     * Log a message at the TRACE level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the TRACE level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     * @param arg4   the fourth argument
+     * @since 1.4
+     */
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4);
+
+    /**
+     * Log a message at the TRACE level according to the specified format
+     * and arguments.
+     * <p/>
      * <p>This form avoids superfluous string concatenation when the logger
      * is disabled for the TRACE level. However, this variant incurs the hidden
      * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
@@ -258,6 +289,35 @@ public interface Logger {
      * Log a message at the DEBUG level according to the specified format
      * and arguments.
      * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the DEBUG level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     */
+    public void debug(String format, Object arg1, Object arg2, Object arg3);
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the DEBUG level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     * @param arg4   the fourth argument
+     */
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4);
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and arguments.
+     * <p/>
      * <p>This form avoids superfluous string concatenation when the logger
      * is disabled for the DEBUG level. However, this variant incurs the hidden
      * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
@@ -379,6 +439,35 @@ public interface Logger {
      * @param arg2   the second argument
      */
     public void info(String format, Object arg1, Object arg2);
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the INFO level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     */
+    public void info(String format, Object arg1, Object arg2, Object arg3);
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the INFO level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     * @param arg4   the fourth argument
+     */
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4);
 
     /**
      * Log a message at the INFO level according to the specified format
@@ -522,6 +611,35 @@ public interface Logger {
     public void warn(String format, Object arg1, Object arg2);
 
     /**
+     * Log a message at the WARN level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the WARN level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     */
+    public void warn(String format, Object arg1, Object arg2, Object arg3);
+
+    /**
+     * Log a message at the WARN level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the WARN level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     * @param arg4   the fourth argument
+     */
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4);
+
+    /**
      * Log an exception (throwable) at the WARN level with an
      * accompanying message.
      *
@@ -630,6 +748,35 @@ public interface Logger {
      * @param arg2   the second argument
      */
     public void error(String format, Object arg1, Object arg2);
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the ERROR level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     */
+    public void error(String format, Object arg1, Object arg2, Object arg3);
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the ERROR level. </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     * @param arg3   the third argument
+     * @param arg4   the fourth argument
+     */
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4);
 
     /**
      * Log a message at the ERROR level according to the specified format

--- a/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
@@ -57,6 +57,14 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.TRACE, format, new Object[] { arg1, arg2 }, null);
     }
 
+    public void trace(String format, Object arg1, Object arg2, Object arg3) {
+        recordEvent(Level.TRACE, format, new Object[] { arg1, arg2, arg3 }, null);
+    }
+
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        recordEvent(Level.TRACE, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
+    }
+
     public void trace(String format, Object[] arguments) {
         recordEvent(Level.TRACE, format, arguments, null);
     }
@@ -106,7 +114,14 @@ public class EventRecodingLogger implements Logger {
 
     public void debug(String format, Object arg1, Object arg2) {
         recordEvent(Level.DEBUG, format, new Object[] { arg1, arg2 }, null);
+    }
 
+    public void debug(String format, Object arg1, Object arg2, Object arg3) {
+        recordEvent(Level.DEBUG, format, new Object[] { arg1, arg2, arg3 }, null);
+    }
+
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        recordEvent(Level.DEBUG, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
     }
 
     public void debug(String format, Object[] arguments) {
@@ -157,6 +172,14 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.INFO, format, new Object[] { arg1, arg2 }, null);
     }
 
+    public void info(String format, Object arg1, Object arg2, Object arg3) {
+        recordEvent(Level.INFO, format, new Object[] { arg1, arg2, arg3 }, null);
+    }
+
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        recordEvent(Level.INFO, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
+    }
+
     public void info(String format, Object[] arguments) {
         recordEvent(Level.INFO, format, arguments, null);
     }
@@ -200,11 +223,18 @@ public class EventRecodingLogger implements Logger {
 
     public void warn(String format, Object arg) {
         recordEvent(Level.WARN, format, new Object[] { arg }, null);
-
     }
 
     public void warn(String format, Object arg1, Object arg2) {
         recordEvent(Level.WARN, format, new Object[] { arg1, arg2 }, null);
+    }
+
+    public void warn(String format, Object arg1, Object arg2, Object arg3) {
+        recordEvent(Level.WARN, format, new Object[] { arg1, arg2, arg3 }, null);
+    }
+
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        recordEvent(Level.WARN, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
     }
 
     public void warn(String format, Object[] arguments) {
@@ -229,7 +259,6 @@ public class EventRecodingLogger implements Logger {
 
     public void warn(Marker marker, String format, Object arg1, Object arg2) {
         recordEvent(Level.WARN, marker, format, new Object[] { arg1, arg2 }, null);
-
     }
 
     public void warn(Marker marker, String format, Object[] arguments) {
@@ -250,17 +279,22 @@ public class EventRecodingLogger implements Logger {
 
     public void error(String format, Object arg) {
         recordEvent(Level.ERROR, format, new Object[] { arg }, null);
-
     }
 
     public void error(String format, Object arg1, Object arg2) {
         recordEvent(Level.ERROR, format, new Object[] { arg1, arg2 }, null);
+    }
 
+    public void error(String format, Object arg1, Object arg2, Object arg3) {
+        recordEvent(Level.ERROR, format, new Object[] { arg1, arg2, arg3 }, null);
+    }
+
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        recordEvent(Level.ERROR, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
     }
 
     public void error(String format, Object[] arguments) {
         recordEvent(Level.ERROR, format, arguments, null);
-
     }
 
     public void error(String msg, Throwable t) {

--- a/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
@@ -122,6 +122,10 @@ final public class MessageFormatter {
         return arrayFormat(messagePattern, new Object[] { arg });
     }
 
+    final public static FormattingTuple format(String messagePattern, Object arg1, Object arg2) {
+        return arrayFormat(messagePattern, new Object[] { arg1, arg2 });
+    }
+
     /**
      *
      * Performs a two argument substitution for the 'messagePattern' passed as
@@ -137,18 +141,18 @@ final public class MessageFormatter {
      *
      * @param messagePattern
      *          The message pattern which will be parsed and formatted
-     * @param arg1
-     *          The argument to be substituted in place of the first formatting
-     *          anchor
-     * @param arg2
-     *          The argument to be substituted in place of the second formatting
-     *          anchor
+     * @param argArray
+     *          The arguments to be substituted in place of the formatting anchors
      * @return The formatted message
      */
-    final public static FormattingTuple format(final String messagePattern, Object arg1, Object arg2) {
-        return arrayFormat(messagePattern, new Object[] { arg1, arg2 });
+    final public static FormattingTuple arrayFormat(final String messagePattern, final Object[] argArray) {
+        Throwable throwableCandidate = getThrowableCandidate(argArray);
+        Object[] args = argArray;
+        if (throwableCandidate != null) {
+            args = trimmedCopy(argArray);
+        }
+        return arrayFormat(messagePattern, args, throwableCandidate);
     }
-
 
     static final Throwable getThrowableCandidate(Object[] argArray) {
         if (argArray == null || argArray.length == 0) {
@@ -160,15 +164,6 @@ final public class MessageFormatter {
             return (Throwable) lastEntry;
         }
         return null;
-    }
-
-    final public static FormattingTuple arrayFormat(final String messagePattern, final Object[] argArray) {
-        Throwable throwableCandidate = getThrowableCandidate(argArray);
-        Object[] args = argArray;
-        if (throwableCandidate != null) {
-            args = trimmedCopy(argArray);
-        }
-        return arrayFormat(messagePattern, args, throwableCandidate);
     }
 
     private static Object[] trimmedCopy(Object[] argArray) {

--- a/slf4j-api/src/main/java/org/slf4j/helpers/NOPLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/NOPLogger.java
@@ -25,7 +25,6 @@
 package org.slf4j.helpers;
 
 import org.slf4j.Logger;
-import org.slf4j.helpers.MarkerIgnoringBase;
 
 /**
  * A direct NOP (no operation) implementation of {@link Logger}.
@@ -79,6 +78,16 @@ public class NOPLogger extends MarkerIgnoringBase {
     }
 
     /** A NOP implementation.  */
+    public final void trace(String format, Object arg1, Object arg2, Object arg3) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
+    public final void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
     public final void trace(String format, Object[] argArray) {
         // NOP
     }
@@ -108,6 +117,16 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation.  */
     public final void debug(String format, Object arg1, Object arg2) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
+    public final void debug(String format, Object arg1, Object arg2, Object arg3) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
+    public final void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
         // NOP
     }
 
@@ -146,6 +165,16 @@ public class NOPLogger extends MarkerIgnoringBase {
     }
 
     /** A NOP implementation.  */
+    final public void info(String format, Object arg1, Object arg2, Object arg3) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
+    final public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
     public final void info(String format, Object[] argArray) {
         // NOP
     }
@@ -178,6 +207,16 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    /** A NOP implementation. */
+    final public void warn(String format, Object arg1, Object arg2, Object arg3) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    final public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        // NOP
+    }
+
     /** A NOP implementation.  */
     public final void warn(String format, Object[] argArray) {
         // NOP
@@ -205,6 +244,16 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void error(String format, Object arg1, Object arg2) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    final public void error(String format, Object arg1, Object arg2, Object arg3) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    final public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
         // NOP
     }
 

--- a/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
@@ -77,6 +77,14 @@ public class SubstituteLogger implements Logger {
         delegate().trace(format, arg1, arg2);
     }
 
+    public void trace(String format, Object arg1, Object arg2, Object arg3) {
+        delegate().trace(format, arg1, arg2, arg3);
+    }
+
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        delegate().trace(format, arg1, arg2, arg3, arg4);
+    }
+
     public void trace(String format, Object[] arguments) {
         delegate().trace(format, arguments);
     }
@@ -123,6 +131,14 @@ public class SubstituteLogger implements Logger {
 
     public void debug(String format, Object arg1, Object arg2) {
         delegate().debug(format, arg1, arg2);
+    }
+
+    public void debug(String format, Object arg1, Object arg2, Object arg3) {
+        delegate().debug(format, arg1, arg2, arg3);
+    }
+
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        delegate().debug(format, arg1, arg2, arg3, arg4);
     }
 
     public void debug(String format, Object[] arguments) {
@@ -173,6 +189,14 @@ public class SubstituteLogger implements Logger {
         delegate().info(format, arg1, arg2);
     }
 
+    public void info(String format, Object arg1, Object arg2, Object arg3) {
+        delegate().info(format, arg1, arg2, arg3);
+    }
+
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        delegate().info(format, arg1, arg2, arg3, arg4);
+    }
+
     public void info(String format, Object[] arguments) {
         delegate().info(format, arguments);
     }
@@ -221,6 +245,14 @@ public class SubstituteLogger implements Logger {
         delegate().warn(format, arg1, arg2);
     }
 
+    public void warn(String format, Object arg1, Object arg2, Object arg3) {
+        delegate().warn(format, arg1, arg2, arg3);
+    }
+
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        delegate().warn(format, arg1, arg2, arg3, arg4);
+    }
+
     public void warn(String format, Object[] arguments) {
         delegate().warn(format, arguments);
     }
@@ -267,6 +299,14 @@ public class SubstituteLogger implements Logger {
 
     public void error(String format, Object arg1, Object arg2) {
         delegate().error(format, arg1, arg2);
+    }
+
+    public void error(String format, Object arg1, Object arg2, Object arg3) {
+        delegate().error(format, arg1, arg2, arg3);
+    }
+
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        delegate().error(format, arg1, arg2, arg3, arg4);
     }
 
     public void error(String format, Object[] arguments) {

--- a/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -25,7 +25,6 @@
 package org.slf4j.impl;
 
 import java.io.PrintStream;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
@@ -359,8 +358,40 @@ public class SimpleLogger extends MarkerIgnoringBase {
         if (INITIALIZED && !isLevelEnabled(level)) {
             return;
         }
-        FormattingTuple tp = MessageFormatter.format(format, arg1, arg2);
-        log(level, tp.getMessage(), tp.getThrowable());
+        formatAndLogImpl(level, format, new Object[] { arg1, arg2 });
+    }
+
+    /**
+     * For formatted messages, first substitute arguments and then log.
+     *
+     * @param level
+     * @param format
+     * @param arg1
+     * @param arg2
+     * @param arg3
+     */
+    private void formatAndLog(int level, String format, Object arg1, Object arg2, Object arg3) {
+        if (INITIALIZED && !isLevelEnabled(level)) {
+            return;
+        }
+        formatAndLogImpl(level, format, new Object[] { arg1, arg2, arg3 });
+    }
+
+    /**
+     * For formatted messages, first substitute arguments and then log.
+     *
+     * @param level
+     * @param format
+     * @param arg1
+     * @param arg2
+     * @param arg3
+     * @param arg4
+     */
+    private void formatAndLog(int level, String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        if (INITIALIZED && !isLevelEnabled(level)) {
+            return;
+        }
+        formatAndLogImpl(level, format, new Object[] { arg1, arg2, arg3, arg4 });
     }
 
     /**
@@ -374,7 +405,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
         if (INITIALIZED && !isLevelEnabled(level)) {
             return;
         }
-        FormattingTuple tp = MessageFormatter.arrayFormat(format, arguments);
+        formatAndLogImpl(level, format, arguments);
+    }
+
+    private void formatAndLogImpl(int level, String format, Object[] args) {
+        FormattingTuple tp = MessageFormatter.arrayFormat(format, args);
         log(level, tp.getMessage(), tp.getThrowable());
     }
 
@@ -416,6 +451,12 @@ public class SimpleLogger extends MarkerIgnoringBase {
      */
     public void trace(String format, Object param1, Object param2) {
         formatAndLog(LOG_LEVEL_TRACE, format, param1, param2);
+    }
+    public void trace(String format, Object param1, Object param2, Object param3) {
+        formatAndLog(LOG_LEVEL_TRACE, format, param1, param2, param3);
+    }
+    public void trace(String format, Object param1, Object param2, Object param3, Object param4) {
+        formatAndLog(LOG_LEVEL_TRACE, format, param1, param2, param3, param4);
     }
 
     /**
@@ -459,6 +500,12 @@ public class SimpleLogger extends MarkerIgnoringBase {
     public void debug(String format, Object param1, Object param2) {
         formatAndLog(LOG_LEVEL_DEBUG, format, param1, param2);
     }
+    public void debug(String format, Object param1, Object param2, Object param3) {
+        formatAndLog(LOG_LEVEL_DEBUG, format, param1, param2, param3);
+    }
+    public void debug(String format, Object param1, Object param2, Object param3, Object param4) {
+        formatAndLog(LOG_LEVEL_DEBUG, format, param1, param2, param3, param4);
+    }
 
     /**
      * Perform double parameter substitution before logging the message of level
@@ -500,6 +547,12 @@ public class SimpleLogger extends MarkerIgnoringBase {
      */
     public void info(String format, Object arg1, Object arg2) {
         formatAndLog(LOG_LEVEL_INFO, format, arg1, arg2);
+    }
+    public void info(String format, Object arg1, Object arg2, Object arg3) {
+        formatAndLog(LOG_LEVEL_INFO, format, arg1, arg2, arg3);
+    }
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        formatAndLog(LOG_LEVEL_INFO, format, arg1, arg2, arg3, arg4);
     }
 
     /**
@@ -543,6 +596,12 @@ public class SimpleLogger extends MarkerIgnoringBase {
     public void warn(String format, Object arg1, Object arg2) {
         formatAndLog(LOG_LEVEL_WARN, format, arg1, arg2);
     }
+    public void warn(String format, Object arg1, Object arg2, Object arg3) {
+        formatAndLog(LOG_LEVEL_WARN, format, arg1, arg2, arg3);
+    }
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        formatAndLog(LOG_LEVEL_WARN, format, arg1, arg2, arg3, arg4);
+    }
 
     /**
      * Perform double parameter substitution before logging the message of level
@@ -584,6 +643,12 @@ public class SimpleLogger extends MarkerIgnoringBase {
      */
     public void error(String format, Object arg1, Object arg2) {
         formatAndLog(LOG_LEVEL_ERROR, format, arg1, arg2);
+    }
+    public void error(String format, Object arg1, Object arg2, Object arg3) {
+        formatAndLog(LOG_LEVEL_ERROR, format, arg1, arg2, arg3);
+    }
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        formatAndLog(LOG_LEVEL_ERROR, format, arg1, arg2, arg3, arg4);
     }
 
     /**


### PR DESCRIPTION
Do not force the user to pass log statement arguments as array, unless there is a need to pass in more than 4 arguments.