### PR TITLE
Support up to 8 parameters when emulating varargs

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/Logger.java
+++ b/slf4j-api/src/main/java/org/slf4j/Logger.java
@@ -150,6 +150,10 @@ public interface Logger {
      * @since 1.4
      */
     public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4);
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6);
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7);
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8);
 
     /**
      * Log a message at the TRACE level according to the specified format
@@ -313,6 +317,10 @@ public interface Logger {
      * @param arg4   the fourth argument
      */
     public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4);
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6);
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7);
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8);
 
     /**
      * Log a message at the DEBUG level according to the specified format
@@ -468,6 +476,10 @@ public interface Logger {
      * @param arg4   the fourth argument
      */
     public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4);
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6);
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7);
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8);
 
     /**
      * Log a message at the INFO level according to the specified format
@@ -638,6 +650,10 @@ public interface Logger {
      * @param arg4   the fourth argument
      */
     public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4);
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6);
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7);
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8);
 
     /**
      * Log an exception (throwable) at the WARN level with an
@@ -777,6 +793,10 @@ public interface Logger {
      * @param arg4   the fourth argument
      */
     public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4);
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6);
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7);
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8);
 
     /**
      * Log a message at the ERROR level according to the specified format

--- a/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
@@ -65,6 +65,19 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.TRACE, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
     }
 
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        recordEvent(Level.TRACE, format, new Object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+    }
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        recordEvent(Level.TRACE, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6 }, null);
+    }
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        recordEvent(Level.TRACE, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 }, null);
+    }
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        recordEvent(Level.TRACE, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 }, null);
+    }
+
     public void trace(String format, Object[] arguments) {
         recordEvent(Level.TRACE, format, arguments, null);
     }
@@ -124,6 +137,19 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.DEBUG, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
     }
 
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        recordEvent(Level.DEBUG, format, new Object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+    }
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        recordEvent(Level.DEBUG, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6 }, null);
+    }
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        recordEvent(Level.DEBUG, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 }, null);
+    }
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        recordEvent(Level.DEBUG, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 }, null);
+    }
+
     public void debug(String format, Object[] arguments) {
         recordEvent(Level.DEBUG, format, arguments, null);
     }
@@ -178,6 +204,19 @@ public class EventRecodingLogger implements Logger {
 
     public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
         recordEvent(Level.INFO, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
+    }
+
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        recordEvent(Level.INFO, format, new Object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+    }
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        recordEvent(Level.INFO, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6 }, null);
+    }
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        recordEvent(Level.INFO, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 }, null);
+    }
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        recordEvent(Level.INFO, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 }, null);
     }
 
     public void info(String format, Object[] arguments) {
@@ -237,6 +276,19 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.WARN, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
     }
 
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        recordEvent(Level.WARN, format, new Object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+    }
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        recordEvent(Level.WARN, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6 }, null);
+    }
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        recordEvent(Level.WARN, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 }, null);
+    }
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        recordEvent(Level.WARN, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 }, null);
+    }
+
     public void warn(String format, Object[] arguments) {
         recordEvent(Level.WARN, format, arguments, null);
     }
@@ -291,6 +343,19 @@ public class EventRecodingLogger implements Logger {
 
     public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
         recordEvent(Level.ERROR, format, new Object[] { arg1, arg2, arg3, arg4 }, null);
+    }
+
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        recordEvent(Level.ERROR, format, new Object[] { arg1, arg2, arg3, arg4, arg5 }, null);
+    }
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        recordEvent(Level.ERROR, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6 }, null);
+    }
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        recordEvent(Level.ERROR, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 }, null);
+    }
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        recordEvent(Level.ERROR, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 }, null);
     }
 
     public void error(String format, Object[] arguments) {

--- a/slf4j-api/src/main/java/org/slf4j/helpers/NOPLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/NOPLogger.java
@@ -88,6 +88,23 @@ public class NOPLogger extends MarkerIgnoringBase {
     }
 
     /** A NOP implementation.  */
+    public final void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
     public final void trace(String format, Object[] argArray) {
         // NOP
     }
@@ -127,6 +144,23 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation.  */
     public final void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
+    public final void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
         // NOP
     }
 
@@ -175,6 +209,23 @@ public class NOPLogger extends MarkerIgnoringBase {
     }
 
     /** A NOP implementation.  */
+    public final void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
     public final void info(String format, Object[] argArray) {
         // NOP
     }
@@ -218,6 +269,23 @@ public class NOPLogger extends MarkerIgnoringBase {
     }
 
     /** A NOP implementation.  */
+    public final void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
     public final void warn(String format, Object[] argArray) {
         // NOP
     }
@@ -254,6 +322,23 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
+        // NOP
+    }
+
+    /** A NOP implementation.  */
+    public final void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        // NOP
+    }
+    /** A NOP implementation.  */
+    public final void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
         // NOP
     }
 

--- a/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
@@ -85,6 +85,19 @@ public class SubstituteLogger implements Logger {
         delegate().trace(format, arg1, arg2, arg3, arg4);
     }
 
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        delegate().trace(format, arg1, arg2, arg3, arg4, arg5);
+    }
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        delegate().trace(format, arg1, arg2, arg3, arg4, arg5, arg6);
+    }
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        delegate().trace(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+    }
+    public void trace(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        delegate().trace(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+    }
+
     public void trace(String format, Object[] arguments) {
         delegate().trace(format, arguments);
     }
@@ -139,6 +152,19 @@ public class SubstituteLogger implements Logger {
 
     public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
         delegate().debug(format, arg1, arg2, arg3, arg4);
+    }
+
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        delegate().debug(format, arg1, arg2, arg3, arg4, arg5);
+    }
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        delegate().debug(format, arg1, arg2, arg3, arg4, arg5, arg6);
+    }
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        delegate().debug(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+    }
+    public void debug(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        delegate().debug(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 
     public void debug(String format, Object[] arguments) {
@@ -197,6 +223,19 @@ public class SubstituteLogger implements Logger {
         delegate().info(format, arg1, arg2, arg3, arg4);
     }
 
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        delegate().info(format, arg1, arg2, arg3, arg4, arg5);
+    }
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        delegate().info(format, arg1, arg2, arg3, arg4, arg5, arg6);
+    }
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        delegate().info(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+    }
+    public void info(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        delegate().info(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+    }
+
     public void info(String format, Object[] arguments) {
         delegate().info(format, arguments);
     }
@@ -253,6 +292,19 @@ public class SubstituteLogger implements Logger {
         delegate().warn(format, arg1, arg2, arg3, arg4);
     }
 
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        delegate().warn(format, arg1, arg2, arg3, arg4, arg5);
+    }
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        delegate().warn(format, arg1, arg2, arg3, arg4, arg5, arg6);
+    }
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        delegate().warn(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+    }
+    public void warn(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        delegate().warn(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+    }
+
     public void warn(String format, Object[] arguments) {
         delegate().warn(format, arguments);
     }
@@ -307,6 +359,19 @@ public class SubstituteLogger implements Logger {
 
     public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
         delegate().error(format, arg1, arg2, arg3, arg4);
+    }
+
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        delegate().error(format, arg1, arg2, arg3, arg4, arg5);
+    }
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        delegate().error(format, arg1, arg2, arg3, arg4, arg5, arg6);
+    }
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        delegate().error(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+    }
+    public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        delegate().error(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 
     public void error(String format, Object[] arguments) {

--- a/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -394,6 +394,31 @@ public class SimpleLogger extends MarkerIgnoringBase {
         formatAndLogImpl(level, format, new Object[] { arg1, arg2, arg3, arg4 });
     }
 
+    private void formatAndLog(int level, String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {
+        if (INITIALIZED && !isLevelEnabled(level)) {
+            return;
+        }
+        formatAndLogImpl(level, format, new Object[] { arg1, arg2, arg3, arg4, arg5 });
+    }
+    private void formatAndLog(int level, String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6) {
+        if (INITIALIZED && !isLevelEnabled(level)) {
+            return;
+        }
+        formatAndLogImpl(level, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6 });
+    }
+    private void formatAndLog(int level, String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7) {
+        if (INITIALIZED && !isLevelEnabled(level)) {
+            return;
+        }
+        formatAndLogImpl(level, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 });
+    }
+    private void formatAndLog(int level, String format, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, Object arg6, Object arg7, Object arg8) {
+        if (INITIALIZED && !isLevelEnabled(level)) {
+            return;
+        }
+        formatAndLogImpl(level, format, new Object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 });
+    }
+
     /**
      * For formatted messages, first substitute arguments and then log.
      *
@@ -459,6 +484,19 @@ public class SimpleLogger extends MarkerIgnoringBase {
         formatAndLog(LOG_LEVEL_TRACE, format, param1, param2, param3, param4);
     }
 
+    public void trace(String format, Object param1, Object param2, Object param3, Object param4, Object param5) {
+        formatAndLog(LOG_LEVEL_TRACE, format, param1, param2, param3, param4, param5);
+    }
+    public void trace(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6) {
+        formatAndLog(LOG_LEVEL_TRACE, format, param1, param2, param3, param4, param5, param6);
+    }
+    public void trace(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7) {
+        formatAndLog(LOG_LEVEL_TRACE, format, param1, param2, param3, param4, param5, param6, param7);
+    }
+    public void trace(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7, Object param8) {
+        formatAndLog(LOG_LEVEL_TRACE, format, param1, param2, param3, param4, param5, param6, param7, param8);
+    }
+
     /**
      * Perform double parameter substitution before logging the message of level
      * TRACE according to the format outlined above.
@@ -505,6 +543,19 @@ public class SimpleLogger extends MarkerIgnoringBase {
     }
     public void debug(String format, Object param1, Object param2, Object param3, Object param4) {
         formatAndLog(LOG_LEVEL_DEBUG, format, param1, param2, param3, param4);
+    }
+
+    public void debug(String format, Object param1, Object param2, Object param3, Object param4, Object param5) {
+        formatAndLog(LOG_LEVEL_DEBUG, format, param1, param2, param3, param4, param5);
+    }
+    public void debug(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6) {
+        formatAndLog(LOG_LEVEL_DEBUG, format, param1, param2, param3, param4, param5, param6);
+    }
+    public void debug(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7) {
+        formatAndLog(LOG_LEVEL_DEBUG, format, param1, param2, param3, param4, param5, param6, param7);
+    }
+    public void debug(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7, Object param8) {
+        formatAndLog(LOG_LEVEL_DEBUG, format, param1, param2, param3, param4, param5, param6, param7, param8);
     }
 
     /**
@@ -555,6 +606,19 @@ public class SimpleLogger extends MarkerIgnoringBase {
         formatAndLog(LOG_LEVEL_INFO, format, arg1, arg2, arg3, arg4);
     }
 
+    public void info(String format, Object param1, Object param2, Object param3, Object param4, Object param5) {
+        formatAndLog(LOG_LEVEL_INFO, format, param1, param2, param3, param4, param5);
+    }
+    public void info(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6) {
+        formatAndLog(LOG_LEVEL_INFO, format, param1, param2, param3, param4, param5, param6);
+    }
+    public void info(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7) {
+        formatAndLog(LOG_LEVEL_INFO, format, param1, param2, param3, param4, param5, param6, param7);
+    }
+    public void info(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7, Object param8) {
+        formatAndLog(LOG_LEVEL_INFO, format, param1, param2, param3, param4, param5, param6, param7, param8);
+    }
+
     /**
      * Perform double parameter substitution before logging the message of level
      * INFO according to the format outlined above.
@@ -603,6 +667,19 @@ public class SimpleLogger extends MarkerIgnoringBase {
         formatAndLog(LOG_LEVEL_WARN, format, arg1, arg2, arg3, arg4);
     }
 
+    public void warn(String format, Object param1, Object param2, Object param3, Object param4, Object param5) {
+        formatAndLog(LOG_LEVEL_WARN, format, param1, param2, param3, param4, param5);
+    }
+    public void warn(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6) {
+        formatAndLog(LOG_LEVEL_WARN, format, param1, param2, param3, param4, param5, param6);
+    }
+    public void warn(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7) {
+        formatAndLog(LOG_LEVEL_WARN, format, param1, param2, param3, param4, param5, param6, param7);
+    }
+    public void warn(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7, Object param8) {
+        formatAndLog(LOG_LEVEL_WARN, format, param1, param2, param3, param4, param5, param6, param7, param8);
+    }
+
     /**
      * Perform double parameter substitution before logging the message of level
      * WARN according to the format outlined above.
@@ -649,6 +726,19 @@ public class SimpleLogger extends MarkerIgnoringBase {
     }
     public void error(String format, Object arg1, Object arg2, Object arg3, Object arg4) {
         formatAndLog(LOG_LEVEL_ERROR, format, arg1, arg2, arg3, arg4);
+    }
+
+    public void error(String format, Object param1, Object param2, Object param3, Object param4, Object param5) {
+        formatAndLog(LOG_LEVEL_ERROR, format, param1, param2, param3, param4, param5);
+    }
+    public void error(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6) {
+        formatAndLog(LOG_LEVEL_ERROR, format, param1, param2, param3, param4, param5, param6);
+    }
+    public void error(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7) {
+        formatAndLog(LOG_LEVEL_ERROR, format, param1, param2, param3, param4, param5, param6, param7);
+    }
+    public void error(String format, Object param1, Object param2, Object param3, Object param4, Object param5, Object param6, Object param7, Object param8) {
+        formatAndLog(LOG_LEVEL_ERROR, format, param1, param2, param3, param4, param5, param6, param7, param8);
     }
 
     /**


### PR DESCRIPTION
Jamod library uses up to 8 parameters when logging with SLF4J