### PR TITLE
Update logger configuration on the fly

### DIFF
--- a/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -114,7 +114,7 @@ public class SimpleLogger extends MarkerIgnoringBase {
     private static final long serialVersionUID = -632788891211436180L;
 
     private static long START_TIME = System.currentTimeMillis();
-    static Hashtable SIMPLE_LOGGER_PROPS = new Hashtable();
+    static final Hashtable SIMPLE_LOGGER_PROPS = new Hashtable();
 
     private static final int LOG_LEVEL_TRACE = LocationAwareLogger.TRACE_INT;
     private static final int LOG_LEVEL_DEBUG = LocationAwareLogger.DEBUG_INT;
@@ -217,7 +217,7 @@ public class SimpleLogger extends MarkerIgnoringBase {
     }
 
     private static void initConfig(Hashtable config) {
-        overwriteHashtable(config, SIMPLE_LOGGER_PROPS);
+        replaceHashtableContents(config, SIMPLE_LOGGER_PROPS);
 
         String defaultLogLevelString = getStringProperty(DEFAULT_LOG_LEVEL_KEY, null);
         if (defaultLogLevelString != null)
@@ -234,7 +234,7 @@ public class SimpleLogger extends MarkerIgnoringBase {
         LOG_FILE = getStringProperty(LOG_FILE_KEY, LOG_FILE);
     }
 
-    private static void overwriteHashtable(Hashtable source, Hashtable destination) {
+    private static void replaceHashtableContents(Hashtable source, Hashtable destination) {
         destination.clear();
 
         Enumeration enumeration = source.keys();

--- a/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -210,14 +210,14 @@ public class SimpleLogger extends MarkerIgnoringBase {
     }
 
     public static void updateConfig(Hashtable config) {
-        synchronized(SIMPLE_LOGGER_PROPS) {
-            initConfig(config);
-        }
+        initConfig(config);
         reinitializeOldLoggerLevels();
     }
 
     private static void initConfig(Hashtable config) {
-        replaceHashtableContents(config, SIMPLE_LOGGER_PROPS);
+        synchronized(SIMPLE_LOGGER_PROPS) {
+            replaceHashtableContents(config, SIMPLE_LOGGER_PROPS);
+        }
 
         String defaultLogLevelString = getStringProperty(DEFAULT_LOG_LEVEL_KEY, null);
         if (defaultLogLevelString != null)

--- a/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -255,7 +255,7 @@ public class SimpleLogger extends MarkerIgnoringBase {
     }
 
     /** The current log level */
-    protected int currentLogLevel = LOG_LEVEL_INFO;
+    protected volatile int currentLogLevel = LOG_LEVEL_INFO;
     /** The short name of this simple log instance */
     private transient String shortLogName = null;
 


### PR DESCRIPTION
- Added new method `SimpleLogger#updateConfig` to be able to update logger configuration.
- Improved `SimpleLogger#initConfig`: instead of storing instance reference of the `HashTable` parameter it makes a copy.